### PR TITLE
remove hard coding of log, result, csv file names

### DIFF
--- a/process_task/process_task.py
+++ b/process_task/process_task.py
@@ -84,9 +84,9 @@ def execute_task_tool(task):
     return True
 
 
-def execute_task_callback(task_callback, user_id, task_id, task_status):
-    # command: "python3 $(task_callback) $(user_id) $(task_id) $(task_status)"
-    process = subprocess.Popen(["python3", task_callback, user_id, task_id, task_status],
+def execute_task_callback(task_callback, user_id, task_id, task_status, task_dot_scan_log_tar, task_scan_result_tar):
+    # command: "python3 $(task_callback) $(user_id) $(task_id) $(task_status) ${task_dot_scan_log_tar} ${task_scan_result_tar}"
+    process = subprocess.Popen(["python3", task_callback, user_id, task_id, task_status, task_dot_scan_log_tar, task_scan_result_tar],
         stdout=subprocess.PIPE, universal_newlines=True)
     read_process_stdout(process)
 
@@ -157,7 +157,9 @@ def main():
     user_id = task['user_id']
     task_id = task['task_id']
     task_status = 'completed'
-    success = execute_task_callback(task_callback, user_id, task_id, task_status)
+    task_dot_scan_log_tar = task['task_dot_scan_log_tar']
+    task_scan_result_tar = task['task_scan_result_tar']
+    success = execute_task_callback(task_callback, user_id, task_id, task_status, task_dot_scan_log_tar, task_scan_result_tar)
     if not success:
         print('execute_task_callback failed.  Exit.')
         return

--- a/process_task/task_result.py
+++ b/process_task/task_result.py
@@ -39,16 +39,22 @@ def parse_arguments():
     global user_id
     global task_id
     global task_status
+    global task_dot_scan_log_tar
+    global task_scan_result_tar
 
     parser = argparse.ArgumentParser()
     parser.add_argument('user_id', help='The user id of the task to update.')
     parser.add_argument('task_id', help='The id of the task to update.')
     parser.add_argument('task_status', help='The status of the task to update.')
+    parser.add_argument('task_dot_scan_log_tar', help='The scan log tar of the task to update.')
+    parser.add_argument('task_scan_result_tar', help='The scan result tar of the task to update.')
 
     args = parser.parse_args()
     user_id = args.user_id
     task_id = args.task_id
     task_status = args.task_status
+    task_dot_scan_log_tar = args.task_dot_scan_log_tar
+    task_scan_result_tar = args.task_scan_result_tar
 
     if user_id is None:
         print('parse_arguments: user_id is missing.')
@@ -62,17 +68,25 @@ def parse_arguments():
         print('parse_arguments: task_status is missing.')
         return False
 
+    if task_dot_scan_log_tar is None:
+        print('parse_arguments: task_dot_scan_log_tar is missing.')
+        return False
+
+    if task_scan_result_tar is None:
+        print('parse_arguments: task_scan_result_tar is missing.')
+        return False
+
     # success
     return True
 
 
-def init_task(user_id, task_id, task_status):
+def init_task(user_id, task_id, task_status, task_dot_scan_log_tar, task_scan_result_tar):
     task = {}
     task['user_id'] = user_id
     task['task_id'] = task_id
     task['task_status'] = task_status
-    task['task_dot_scan_log_tar'] = '.scan_log.tar.gz'
-    task['task_scan_result_tar'] = 'scan_result.tar.gz'
+    task['task_dot_scan_log_tar'] = task_dot_scan_log_tar
+    task['task_scan_result_tar'] = task_scan_result_tar
     return task
 
 
@@ -98,8 +112,10 @@ def main():
     print(f'user_id: {user_id}')
     print(f'task_id: {task_id}')
     print(f'task_status: {task_status}')
+    print(f'task_dot_scan_log_tar: {task_dot_scan_log_tar}')
+    print(f'task_scan_result_tar: {task_scan_result_tar}')
 
-    task = init_task(user_id, task_id, task_status)
+    task = init_task(user_id, task_id, task_status, task_dot_scan_log_tar, task_scan_result_tar)
 
     task_file_attribute_name = 'task_dot_scan_log_tar'
     success = taskfile.upload_task_file(log_bucket_name, task, task_file_attribute_name)

--- a/upload_task_issues/taskissue.py
+++ b/upload_task_issues/taskissue.py
@@ -72,7 +72,7 @@ def upload_tmp_file(bucket_name, task, tmp_file_name):
 
 
 def write_task_issues(issue_table, bucket_name, task, scan_result_tar_blob):
-    # get user_id, task_id
+    # get user_id, task_id, task_issues_csv
     user_id = get_task_attribute_value(task, 'user_id')
     if user_id == '':
         return False
@@ -81,8 +81,12 @@ def write_task_issues(issue_table, bucket_name, task, scan_result_tar_blob):
     if task_id == '':
         return False
 
+    task_issues_csv = get_task_attribute_value(task, 'task_issues_csv')
+    if task_issues_csv == '':
+        return False
+
     # write csv file header
-    csv_file_name = task_id + '_issues.csv'
+    csv_file_name = task_issues_csv
     csv_file_full_path = '/tmp/' + csv_file_name
     success = csvfile.write_task_issues_csv_header(csv_file_full_path)
     if not success:


### PR DESCRIPTION
remove hard coding of file names in:
process_task.py, task_result.py: task_dot_scan_log_tar, task_scan_result_tar
upload_task_issues/taskissue.py: task_issues_csv
