### PR TITLE
comment out PDF export

### DIFF
--- a/generate-task-summary/src/main/java/com/rwang5688/GenerateTaskSummaryHandler.java
+++ b/generate-task-summary/src/main/java/com/rwang5688/GenerateTaskSummaryHandler.java
@@ -231,7 +231,8 @@ public class GenerateTaskSummaryHandler implements RequestHandler<SQSEvent, Stri
         downloadTaskIssuesCSV();
         readTaskIssuesCSVData();
         copyTaskSummaryPDFFile();
-        exportTaskIssuesPDFFile();
+        // open issue: JRExport.exportPDFFile times out inside Lambda function
+        //exportTaskIssuesPDFFile();
       } catch (Exception e) {
         logger.error("handleRequest: " + e);
       }


### PR DESCRIPTION
must comment out so Lambda function can end normally.
otherwise, SQS queue will be stuck.