### PR TITLE
move s3util.get_file_object

### DIFF
--- a/process_task/s3util.py
+++ b/process_task/s3util.py
@@ -43,6 +43,17 @@ def get_bucket(bucket_name):
     return result
 
 
+def get_file_object(bucket_name, object_name):
+    s3 = get_s3_client()
+    file_object = None
+    try:
+        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return None
+    return file_object
+
+
 def list_files(bucket_name):
     # Retrieve the list of existing files
     s3 = get_s3_client()
@@ -80,15 +91,4 @@ def download_file(bucket_name, object_name, file_name=None):
         logging.error(e)
         return False
     return True
-
-
-def get_file_object(bucket_name, object_name):
-    s3 = get_s3_client()
-    file_object = None
-    try:
-        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
-    except ClientError as e:
-        logging.error(e)
-        return None
-    return file_object
 

--- a/submit_task/s3util.py
+++ b/submit_task/s3util.py
@@ -43,6 +43,17 @@ def get_bucket(bucket_name):
     return result
 
 
+def get_file_object(bucket_name, object_name):
+    s3 = get_s3_client()
+    file_object = None
+    try:
+        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return None
+    return file_object
+
+
 def list_files(bucket_name):
     # Retrieve the list of existing files
     s3 = get_s3_client()
@@ -80,15 +91,4 @@ def download_file(bucket_name, object_name, file_name=None):
         logging.error(e)
         return False
     return True
-
-
-def get_file_object(bucket_name, object_name):
-    s3 = get_s3_client()
-    file_object = None
-    try:
-        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
-    except ClientError as e:
-        logging.error(e)
-        return None
-    return file_object
 

--- a/upload_task_issues/s3util.py
+++ b/upload_task_issues/s3util.py
@@ -43,6 +43,17 @@ def get_bucket(bucket_name):
     return result
 
 
+def get_file_object(bucket_name, object_name):
+    s3 = get_s3_client()
+    file_object = None
+    try:
+        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return None
+    return file_object
+
+
 def list_files(bucket_name):
     # Retrieve the list of existing files
     s3 = get_s3_client()
@@ -80,15 +91,4 @@ def download_file(bucket_name, object_name, file_name=None):
         logging.error(e)
         return False
     return True
-
-
-def get_file_object(bucket_name, object_name):
-    s3 = get_s3_client()
-    file_object = None
-    try:
-        file_object = s3.get_object(Bucket=bucket_name, Key=object_name)
-    except ClientError as e:
-        logging.error(e)
-        return None
-    return file_object
 


### PR DESCRIPTION
just moving s3util.get_file_object from bottom of the file to the middle of the file.
the purpose is to let get_bucket and get_file_object be together.
there is no change to functionality.

I want to put s3util.get_file_object in a more logical place.
we will make use of s3util.get_file_object as part of the Java RT cache functionality.