### PR TITLE
After setting lambda function timeout value from default timeout valu…

### DIFF
--- a/resources/task-exec-queues.yml
+++ b/resources/task-exec-queues.yml
@@ -19,8 +19,10 @@ Resources:
     Type: "AWS::SQS::Queue"
     Properties:
       QueueName: "${self:custom.uploadTaskIssuesQueue}"
+      VisibilityTimeout: 3000
   GenerateTaskSummaryQueue:
     Type: "AWS::SQS::Queue"
     Properties:
       QueueName: "${self:custom.generateTaskSummaryQueue}"
+      VisibilityTimeout: 3000
 


### PR DESCRIPTION
…e 6 seconds to 600 seconds, deploy upload task issues and generate task summary will fail. Also need to increase the visibility timeout value of the corresponding queue.