### PR TITLE
Some large projects need long time to scan. Till now project need mor…

### DIFF
--- a/create_task/sqsutil.py
+++ b/create_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/create_task/taskmessage.py
+++ b/create_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/process_task/sqsutil.py
+++ b/process_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/process_task/taskmessage.py
+++ b/process_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/resources/task-exec-queues.yml
+++ b/resources/task-exec-queues.yml
@@ -11,6 +11,7 @@ Resources:
     Type: "AWS::SQS::Queue"
     Properties:
       QueueName: "${self:custom.processTaskQueue}"
+      VisibilityTimeout: 9000
   UpdateTaskQueue:
     Type: "AWS::SQS::Queue"
     Properties:

--- a/submit_task/sqsutil.py
+++ b/submit_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/submit_task/taskmessage.py
+++ b/submit_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/update_task/sqsutil.py
+++ b/update_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/update_task/taskmessage.py
+++ b/update_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/upload_task_issues/sqsutil.py
+++ b/upload_task_issues/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/upload_task_issues/taskmessage.py
+++ b/upload_task_issues/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True


### PR DESCRIPTION
…e than 2 hours. To avoid scan same projects in parallel scan, change process task queue's visibility timeout to 2.5 hours